### PR TITLE
fix: stylesheet loading

### DIFF
--- a/src/mergeHeadContents.ts
+++ b/src/mergeHeadContents.ts
@@ -19,15 +19,14 @@ export default function mergeHeadContents(
 		.forEach(({ el }) => currentHead.removeChild(el));
 
 	// Insert tag *after* previous version of itself to preserve JS variable scope and CSS cascade
-    const newAddTags = addTags
-    .filter(({ el }) => shouldManageTag(el))
-    .map((tag) => {
-        let newEl = tag.el.cloneNode(true) as Element;
-        currentHead.insertBefore(newEl, currentHead.children[(tag.index || 0) + 1] || null);
+	const newAddTags = addTags
+		.filter(({ el }) => shouldManageTag(el))
+		.map((tag) => {
+			let newEl = tag.el.cloneNode(true) as Element;
+			currentHead.insertBefore(newEl, currentHead.children[(tag.index || 0) + 1] || null);
 
-        return { ...tag, el: newEl };
-    });
-
+			return { ...tag, el: newEl };
+		});
 
 	return {
 		removed: removeTags.map(({ el }) => el),

--- a/src/mergeHeadContents.ts
+++ b/src/mergeHeadContents.ts
@@ -19,15 +19,19 @@ export default function mergeHeadContents(
 		.forEach(({ el }) => currentHead.removeChild(el));
 
 	// Insert tag *after* previous version of itself to preserve JS variable scope and CSS cascade
-	addTags
-		.filter(({ el }) => shouldManageTag(el))
-		.forEach(({ el, index = 0 }) => {
-			currentHead.insertBefore(el.cloneNode(true), currentHead.children[index + 1] || null);
-		});
+    const newAddTags = addTags
+    .filter(({ el }) => shouldManageTag(el))
+    .map((tag) => {
+        let newEl = tag.el.cloneNode(true) as Element;
+        currentHead.insertBefore(newEl, currentHead.children[(tag.index || 0) + 1] || null);
+
+        return { ...tag, el: newEl };
+    });
+
 
 	return {
 		removed: removeTags.map(({ el }) => el),
-		added: addTags.map(({ el }) => el)
+		added: newAddTags.map(({ el }) => el)
 	};
 }
 

--- a/src/waitForAssets.ts
+++ b/src/waitForAssets.ts
@@ -13,18 +13,23 @@ export function waitForStylesheet(
 	element: HTMLLinkElement,
 	timeoutMs: number = 0
 ): Promise<HTMLLinkElement> {
+	let timeoutId: ReturnType<typeof setTimeout>;
+
 	const whenLoaded = (cb: () => void) => {
 		if (element.sheet) {
 			cb();
 		} else {
-			setTimeout(() => whenLoaded(cb), 10);
+			timeoutId = setTimeout(() => whenLoaded(cb), 10);
 		}
 	};
 
 	return new Promise((resolve) => {
 		whenLoaded(() => resolve(element));
 		if (timeoutMs > 0) {
-			setTimeout(() => resolve(element), timeoutMs);
+			setTimeout(() => {
+				if (timeoutId) clearTimeout(timeoutId);
+				resolve(element);
+			}, timeoutMs);
 		}
 	});
 }


### PR DESCRIPTION
**Description**

This PR aims to fix the loading of Stylesheets.
Currently they are cloned before inserted to the current page, but the one that is awaited to be loaded is not the cloned one. So it never loads.
I am fixing this by returning the newly cloned one. 

It also fix the infinite loop / memory leak in the `waitForStylesheet` function that occurs when the provided timeout is elapsed and the stylesheet never loads.

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required
